### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/src/modules/auth/auth.routes.ts
+++ b/server/src/modules/auth/auth.routes.ts
@@ -8,6 +8,6 @@ const router = Router();
 
 router.post('/register', authLimiter, authController.register);
 router.post('/login', authLimiter, authController.login);
-router.get('/me', authenticate, authController.getMe);
+router.get('/me', authLimiter, authenticate, authController.getMe);
 
 export default router;


### PR DESCRIPTION
Potential fix for [https://github.com/srinandahr/project-product/security/code-scanning/2](https://github.com/srinandahr/project-product/security/code-scanning/2)

In general, to fix missing rate limiting on a route, you should apply an appropriate rate-limiting middleware to that route (or to a router/global scope) so that expensive operations, especially on authentication/authorization endpoints, cannot be abused by high request volumes.

In this file, the best fix with no functional regression is to reuse the already-imported `authLimiter` middleware on the `/me` route, exactly as is done for `/register` and `/login`. The file already imports `authLimiter` from `../../middlewares/rateLimit.middleware` and uses it on other routes, so no new imports or helpers are needed. We only need to modify line 11 so that the middleware chain for `/me` becomes `authLimiter, authenticate, authController.getMe`. This preserves existing authentication behavior and simply adds a rate-limiting step before it, consistent with `/register` and `/login`.

Concretely, in `server/src/modules/auth/auth.routes.ts`, change the `/me` route definition from:

```ts
router.get('/me', authenticate, authController.getMe);
```

to:

```ts
router.get('/me', authLimiter, authenticate, authController.getMe);
```

No other lines in this file need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
