### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/src/modules/dailyCheckins/dailyCheckins.routes.ts
+++ b/server/src/modules/dailyCheckins/dailyCheckins.routes.ts
@@ -1,10 +1,19 @@
 import { Router } from 'express';
 import * as checkinController from './dailyCheckins.controller';
 import { authenticate } from '../../middlewares/auth.middleware';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const dailyCheckinsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.use(authenticate);
+router.use(dailyCheckinsRateLimiter);
 
 router.post('/', checkinController.createCheckin);
 router.get('/today', checkinController.getTodayCheckin);


### PR DESCRIPTION
Potential fix for [https://github.com/srinandahr/project-product/security/code-scanning/3](https://github.com/srinandahr/project-product/security/code-scanning/3)

In general, to fix missing rate limiting for Express handlers, you introduce a rate-limiting middleware (such as `express-rate-limit`) and apply it either globally or to specific routers or routes that perform expensive operations. This ensures that, even if an attacker sends many requests, there is an enforced maximum rate per IP/user, reducing the risk of denial-of-service.

For this specific file, the most conservative fix, without changing existing functionality, is to add a rate limiter middleware to this router and apply it to the daily check-in routes. Since we can only modify the provided snippet, we should: (1) import a well-known rate-limiting library (`express-rate-limit`), (2) create a limiter instance with reasonable defaults (e.g., a window and max number of requests), and (3) use `router.use(limiter)` after authentication so that all subsequent routes in this router are rate limited. We won’t remove or reorder existing middlewares except placing the limiter after `authenticate` so that only authenticated traffic is subject to these limits and the authentication step remains first in the chain.

Concretely:
- In `server/src/modules/dailyCheckins/dailyCheckins.routes.ts`, add an import for `express-rate-limit`.
- Define a `dailyCheckinsRateLimiter` using `rateLimit({ windowMs: ..., max: ..., standardHeaders: true, legacyHeaders: false })`.
- Add `router.use(dailyCheckinsRateLimiter);` immediately after `router.use(authenticate);` so all three routes (`POST /`, `GET /today`, `GET /streak`) are protected by rate limiting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
