### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/src/modules/dashboard/dashboard.routes.ts
+++ b/server/src/modules/dashboard/dashboard.routes.ts
@@ -1,9 +1,16 @@
 import { Router } from 'express';
 import * as dashboardController from './dashboard.controller';
 import { authenticate } from '../../middlewares/auth.middleware';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const dashboardRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+router.use(dashboardRateLimiter);
 router.use(authenticate);
 
 router.get('/overview', dashboardController.getOverview);


### PR DESCRIPTION
Potential fix for [https://github.com/srinandahr/project-product/security/code-scanning/4](https://github.com/srinandahr/project-product/security/code-scanning/4)

In general, the fix is to add a rate-limiting middleware to the router so that requests to `/overview` (and potentially other dashboard routes) are throttled to a safe rate. A common approach in Express is to use the well-known `express-rate-limit` package, configure a limiter (e.g., per IP, with a safe window and max request count), and apply it via `router.use(limiter)` or to specific routes.

For this file, the least intrusive and clearest fix is:
- Import `express-rate-limit`.
- Create a `dashboardRateLimiter` configured for a reasonable window and request cap (e.g., 100 requests per 15 minutes, matching the example).
- Apply this limiter to the router before the `authenticate` middleware and route definitions, or at least before the `/overview` route. Placing it before `authenticate` ensures expensive auth work is also protected; placing it after would still protect the controller but not auth. The safer option is to apply it to the router as a whole right after `Router()` is created.

Concretely:
- In `server/src/modules/dashboard/dashboard.routes.ts`, add a new import for `express-rate-limit`.
- Define `const dashboardRateLimiter = rateLimit({ windowMs: 15 * 60 * 1000, max: 100 });` (or similar).
- Insert `router.use(dashboardRateLimiter);` after `const router = Router();` and before `router.use(authenticate);`.
No existing APIs or route paths change; we only add middleware, maintaining existing functionality while introducing rate limiting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
