### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/server/src/modules/leetcode/leetcode.routes.ts
+++ b/server/src/modules/leetcode/leetcode.routes.ts
@@ -1,10 +1,19 @@
 import { Router } from 'express';
 import * as leetCodeController from './leetcode.controller';
 import { authenticate } from '../../middlewares/auth.middleware';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const leetCodeStatsLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per window
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+});
+
 router.use(authenticate);
+router.use(leetCodeStatsLimiter);
 
 router.get('/:username', leetCodeController.getStats);
 


### PR DESCRIPTION
Potential fix for [https://github.com/srinandahr/project-product/security/code-scanning/6](https://github.com/srinandahr/project-product/security/code-scanning/6)

In general, the fix is to introduce a rate-limiting middleware and apply it to this router (either globally on the router or specifically on the `/:username` route) so that repeated requests from the same client are capped over a given time window. For Express, the standard approach is to use the `express-rate-limit` package.

For this specific file, the best non‑breaking approach is:

1. Import `express-rate-limit`.
2. Define a limiter instance tailored to this LeetCode stats route (for example, a moderate per‑minute cap so normal usage is unaffected, but abuse is limited).
3. Apply this limiter to the router before the route definition, while keeping `authenticate` in place.

Concretely in `server/src/modules/leetcode/leetcode.routes.ts`:

- Add an import for `express-rate-limit`.
- Create a `leetCodeStatsLimiter` (or similar) with a sensible `windowMs` and `max` (e.g., 15 minutes, 100 requests).
- Use `router.use(leetCodeStatsLimiter);` after `router.use(authenticate);` so that requests must be authenticated and are also rate-limited before reaching `getStats`.

This avoids changing controller behavior and only adds a protective layer around it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
