### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/server/src/modules/resumes/resumes.routes.ts
+++ b/server/src/modules/resumes/resumes.routes.ts
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 import * as resumeController from './resumes.controller';
 import { authenticate } from '../../middlewares/auth.middleware';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const resumeRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs on resume routes
+});
+
 router.use(authenticate);
+router.use(resumeRateLimiter);
 
 import { upload } from '../../middlewares/upload.middleware';
 


### PR DESCRIPTION
Potential fix for [https://github.com/srinandahr/project-product/security/code-scanning/8](https://github.com/srinandahr/project-product/security/code-scanning/8)

In general, the fix is to introduce a rate-limiting middleware (for example using `express-rate-limit`) and apply it to the resume routes so that authenticated endpoints cannot be called arbitrarily often. This limits the impact of malicious or buggy clients making excessive requests.

The best way to fix this snippet without changing existing behavior is:
- Import a well-known rate limiting library such as `express-rate-limit`.
- Define a limiter instance for these routes with a reasonable window and max request count (e.g., 100 requests per 15 minutes per IP; exact numbers can be tuned later).
- Apply the limiter to the router, ideally after authentication (so it’s per authenticated client/IP on these protected endpoints) and before the route handlers, so all these routes are rate-limited.

Concretely, in `server/src/modules/resumes/resumes.routes.ts`:
- Add an import for `express-rate-limit`.
- Create a `resumeRateLimiter` (or similarly named) middleware constant using `rateLimit({ ... })`.
- Use `router.use(resumeRateLimiter);` so that all subsequent routes (`POST /`, `GET /`, `PATCH /:id`, `DELETE /:id`) are rate-limited.
- Keep all existing routes and middleware ordering intact apart from inserting the limiter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
